### PR TITLE
fix: remove MCP reinitialization in SSE mode that overwrote all tools

### DIFF
--- a/src/servicenow_mcp/server_sse.py
+++ b/src/servicenow_mcp/server_sse.py
@@ -62,7 +62,6 @@ class ServiceNowMCP(ServiceNowMCP):
             config: Server configuration, either as a dictionary or ServerConfig object.
         """
         super().__init__(config)
-        self.mcp_server = FastMCP("ServiceNow", port=8080, host="localhost")
 
     def start(self, host: str = "0.0.0.0", port: int = 8080):
         """


### PR DESCRIPTION
This removes an unnecessary MCP reinitialization that occurred in SSE server mode.
The reinit caused the MCP instance to be overwritten, resulting in no tools being available at all, since they were not properly initialized again.